### PR TITLE
Bump jackson.version from 2.9.7 to 2.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <rhino.version>1.7.7.2</rhino.version>
     <slf4j.version>1.7.10</slf4j.version>
     <commons-lang3.version>3.8.1</commons-lang3.version>
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.12.1</jackson.version>
     <freemarker.version>2.3.19</freemarker.version>
     <!-- testing libs -->
     <testng.version>6.7</testng.version>


### PR DESCRIPTION
Bumps `jackson.version` from 2.9.7 to 2.12.1.

Updates `jackson-core` from 2.9.7 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.9.7...jackson-core-2.12.1)

Updates `jackson-databind` from 2.9.7 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)